### PR TITLE
Add optional filters to daily report tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         ],
         "analytics": [
           "hourly_sales",
+          "daily_report",
           "sales_gaps",
           "year_over_year"
 

--- a/src/db/engine.py
+++ b/src/db/engine.py
@@ -11,46 +11,54 @@ from sqlalchemy.ext.declarative import declarative_base
 logger = logging.getLogger(__name__)
 
 # Get environment variables
-DB_USERNAME = os.getenv('DB_USERNAME')
-DB_PASSWORD = os.getenv('DB_PASSWORD')
-DB_SERVER = os.getenv('DB_SERVER')
-DB_DATABASE = os.getenv('DB_DATABASE')
-ODBC_DRIVER = os.getenv('ODBC_DRIVER', 'ODBC Driver 17 for SQL Server')
-POOL_SIZE = int(os.getenv('POOL_SIZE', '10'))
-MAX_OVERFLOW = int(os.getenv('MAX_OVERFLOW', '20'))
+DB_USERNAME = os.getenv("DB_USERNAME")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+DB_SERVER = os.getenv("DB_SERVER")
+DB_DATABASE = os.getenv("DB_DATABASE")
+DATABASE_URL_ENV = os.getenv("DATABASE_URL")
+ODBC_DRIVER = os.getenv("ODBC_DRIVER", "ODBC Driver 17 for SQL Server")
+POOL_SIZE = int(os.getenv("POOL_SIZE", "10"))
+MAX_OVERFLOW = int(os.getenv("MAX_OVERFLOW", "20"))
 
-# Validate required environment variables
-if not all([DB_USERNAME, DB_PASSWORD, DB_SERVER, DB_DATABASE]):
-    missing = []
-    if not DB_USERNAME: missing.append('DB_USERNAME')
-    if not DB_PASSWORD: missing.append('DB_PASSWORD')
-    if not DB_SERVER: missing.append('DB_SERVER')
-    if not DB_DATABASE: missing.append('DB_DATABASE')
-    raise ValueError(f"Missing required environment variables: {', '.join(missing)}")
+if DATABASE_URL_ENV:
+    DATABASE_URL = DATABASE_URL_ENV
+else:
+    if not all([DB_USERNAME, DB_PASSWORD, DB_SERVER, DB_DATABASE]):
+        missing = []
+        if not DB_USERNAME:
+            missing.append("DB_USERNAME")
+        if not DB_PASSWORD:
+            missing.append("DB_PASSWORD")
+        if not DB_SERVER:
+            missing.append("DB_SERVER")
+        if not DB_DATABASE:
+            missing.append("DB_DATABASE")
+        raise ValueError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
 
-# URL-encode password to handle special characters
-encoded_password = quote_plus(DB_PASSWORD)
+    encoded_password = quote_plus(DB_PASSWORD)
+    DATABASE_URL = (
+        f"mssql+pyodbc://{DB_USERNAME}:{encoded_password}@{DB_SERVER}/{DB_DATABASE}"
+        f"?driver={ODBC_DRIVER.replace(' ', '+')}"
+    )
 
-# Construct the database URL properly
-DATABASE_URL = (
-    f"mssql+pyodbc://{DB_USERNAME}:{encoded_password}@{DB_SERVER}/{DB_DATABASE}"
-    f"?driver={ODBC_DRIVER.replace(' ', '+')}"
-)
+    # Optional: Add additional connection parameters
+    # DATABASE_URL += "&TrustServerCertificate=yes"  # For self-signed certificates
+    # DATABASE_URL += "&Encrypt=yes"  # For encrypted connections
 
-# Optional: Add additional connection parameters
-# DATABASE_URL += "&TrustServerCertificate=yes"  # For self-signed certificates
-# DATABASE_URL += "&Encrypt=yes"  # For encrypted connections
-
-logger.info(f"Connecting to SQL Server: {DB_SERVER}/{DB_DATABASE}")
+    logger.info(f"Connecting to SQL Server: {DB_SERVER}/{DB_DATABASE}")
 
 # Create the engine
-engine = create_engine(
-    DATABASE_URL,
-    pool_size=POOL_SIZE,
-    max_overflow=MAX_OVERFLOW,
-    pool_pre_ping=True,  # Verify connections before using
-    echo=False,  # Set to True for SQL debugging
-)
+engine_args = {
+    "pool_pre_ping": True,
+    "echo": False,
+}
+if not DATABASE_URL_ENV:
+    engine_args["pool_size"] = POOL_SIZE
+    engine_args["max_overflow"] = MAX_OVERFLOW
+
+engine = create_engine(DATABASE_URL, **engine_args)
 
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -21,6 +21,7 @@ def load_app(monkeypatch):
         ("src.tools.basket.item_correlation", "item_correlation_tool"),
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
+        ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
         ("src.tools.item_lookup", "item_lookup_tool"),
@@ -53,7 +54,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 13
+    assert len(resp.json()) == 14
 
 
 def test_fastapi_call_tool(monkeypatch):

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -44,3 +44,12 @@ def test_tool_registration(monkeypatch):
     assert hasattr(server, "run")
     assert len(server.tools) == 13
     assert all(hasattr(t, "name") for t in server.tools)
+
+
+def test_daily_report_schema():
+    from src.tools.analytics.daily_report import daily_report_tool
+
+    props = daily_report_tool.inputSchema["properties"]
+    assert "item_id" in props
+    assert "item_name" in props
+    assert "category" in props

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -19,6 +19,7 @@ def load_server(monkeypatch):
         ("src.tools.basket.item_correlation", "item_correlation_tool"),
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
+        ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
         ("src.tools.item_lookup", "item_lookup_tool"),
@@ -42,7 +43,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 13
+    assert len(server.tools) == 14
     assert all(hasattr(t, "name") for t in server.tools)
 
 

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -10,6 +10,7 @@ from .tools.basket.cross_sell import cross_sell_opportunities_tool
 from .tools.analytics.hourly_sales import hourly_sales_tool
 from .tools.analytics.sales_gaps import sales_gaps_tool
 from .tools.analytics.year_over_year import year_over_year_tool
+from .tools.analytics.daily_report import daily_report_tool
 from .tools.item_lookup import item_lookup_tool
 from .tools.site_lookup import site_lookup_tool
 from .tools.get_today_date import get_today_date_tool
@@ -23,6 +24,7 @@ TOOLS: list[Tool] = [
     item_correlation_tool,
     cross_sell_opportunities_tool,
     hourly_sales_tool,
+    daily_report_tool,
     sales_gaps_tool,
     year_over_year_tool,
     item_lookup_tool,

--- a/src/tools/analytics/__init__.py
+++ b/src/tools/analytics/__init__.py
@@ -3,9 +3,11 @@
 from .hourly_sales import hourly_sales_tool
 from .sales_gaps import sales_gaps_tool
 from .year_over_year import year_over_year_tool
+from .daily_report import daily_report_tool
 
 __all__ = [
     "hourly_sales_tool",
     "sales_gaps_tool",
     "year_over_year_tool",
+    "daily_report_tool",
 ]

--- a/src/tools/analytics/daily_report.py
+++ b/src/tools/analytics/daily_report.py
@@ -1,0 +1,97 @@
+"""Summarize daily sales totals with optional filters."""
+
+from typing import Optional, Dict, Any
+
+from mcp.types import Tool
+
+from ...db.connection import execute_query
+from ...db.models import SALES_FACT_VIEW
+from ..utils import validate_date_range, create_tool_response
+
+
+async def daily_report_impl(
+    start_date: str,
+    end_date: str,
+    site_id: Optional[int] = None,
+    item_id: Optional[int] = None,
+    item_name: Optional[str] = None,
+    category: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return daily totals for quantity, sales and transactions."""
+
+    start_date, end_date = validate_date_range(start_date, end_date)
+
+    sql = f"""
+    SELECT
+        SaleDate,
+        SUM(QtySold) AS total_quantity,
+        SUM(GrossSales) AS total_sales,
+        COUNT(DISTINCT TransactionID) AS transaction_count
+    FROM {SALES_FACT_VIEW}
+    WHERE SaleDate BETWEEN :start_date AND :end_date
+    """
+
+    params: Dict[str, Any] = {"start_date": start_date, "end_date": end_date}
+
+    if site_id is not None:
+        sql += " AND SiteID = :site_id"
+        params["site_id"] = site_id
+
+    if item_id is not None:
+        sql += " AND ItemID = :item_id"
+        params["item_id"] = item_id
+    elif item_name:
+        sql += " AND ItemName LIKE :item_name"
+        params["item_name"] = f"%{item_name}%"
+
+    if category:
+        sql += " AND Category LIKE :category"
+        params["category"] = f"%{category}%"
+
+    sql += " GROUP BY SaleDate ORDER BY SaleDate"
+
+    try:
+        results = execute_query(sql, params)
+        for row in results:
+            if "SaleDate" in row and row["SaleDate"]:
+                row["SaleDate"] = str(row["SaleDate"])
+
+        metadata = {
+            "date_range": f"{start_date} to {end_date}",
+            "filters": {
+                "site_id": site_id,
+                "item_id": item_id,
+                "item_name": item_name,
+                "category": category,
+            },
+        }
+        return create_tool_response(results, sql, params, metadata)
+    except Exception as e:  # pragma: no cover - db errors depend on env
+        return create_tool_response([], sql, params, error=str(e))
+
+
+daily_report_tool = Tool(
+    name="daily_report",
+    description=(
+        "Summarise sales by day. Optional filters allow narrowing by site, "
+        "item or category."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "start_date": {"type": "string", "description": "Start date (YYYY-MM-DD)"},
+            "end_date": {"type": "string", "description": "End date (YYYY-MM-DD)"},
+            "site_id": {"type": "integer", "description": "Optional site filter"},
+            "item_id": {"type": "integer", "description": "Exact item ID"},
+            "item_name": {"type": "string", "description": "Item name (partial match)"},
+            "category": {
+                "type": "string",
+                "description": "Category filter (partial match)",
+            },
+        },
+        "required": ["start_date", "end_date"],
+        "additionalProperties": False,
+    },
+)
+
+daily_report_tool._implementation = daily_report_impl


### PR DESCRIPTION
## Summary
- implement `daily_report` analytics tool with optional `item_id`, `item_name`, and `category`
- allow `DATABASE_URL` override in DB engine and adjust engine args
- test schema fields for `daily_report`

## Testing
- `pip install mcp httpx fastapi sqlalchemy pyodbc python-dateutil fastapi-mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d74319a20832b9962f5e56777db41