### PR TITLE
Add peak hours and related analytics tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ date range. Accepts an optional `site_id` filter.
 Generate a simple per-day report of sales and transaction totals. Call
 `POST /daily_report` with `start_date` and `end_date` like the other tools.
 
+### `peak_hours`
+
+Return the hours of the day with the greatest sales totals. Supports optional
+`site_id` filtering and limiting the number of results.
+
+### `sales_anomalies`
+
+Highlight dates where total sales deviate from the average by a configurable
+number of standard deviations.
+
+### `product_velocity`
+
+List the fastest selling items ranked by quantity. You can filter by `site_id`
+and control how many items are returned.
+
+### `low_movement`
+
+Identify slow-moving items whose quantity sold is below a given threshold.
+
 ## Installation
 
 1. Clone the repository:

--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -22,6 +22,10 @@ def load_app(monkeypatch):
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
+        ("src.tools.analytics.peak_hours", "peak_hours_tool"),
+        ("src.tools.analytics.sales_anomalies", "sales_anomalies_tool"),
+        ("src.tools.analytics.product_velocity", "product_velocity_tool"),
+        ("src.tools.analytics.low_movement", "low_movement_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
         ("src.tools.item_lookup", "item_lookup_tool"),
@@ -54,7 +58,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 14
+    assert len(resp.json()) == 18
 
 
 def test_fastapi_call_tool(monkeypatch):

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -20,6 +20,10 @@ def load_server(monkeypatch):
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
+        ("src.tools.analytics.peak_hours", "peak_hours_tool"),
+        ("src.tools.analytics.sales_anomalies", "sales_anomalies_tool"),
+        ("src.tools.analytics.product_velocity", "product_velocity_tool"),
+        ("src.tools.analytics.low_movement", "low_movement_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
         ("src.tools.item_lookup", "item_lookup_tool"),
@@ -43,7 +47,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 14
+    assert len(server.tools) == 18
     assert all(hasattr(t, "name") for t in server.tools)
 
 

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -9,6 +9,10 @@ from .tools.basket.item_correlation import item_correlation_tool
 from .tools.basket.cross_sell import cross_sell_opportunities_tool
 from .tools.analytics.daily_report import daily_report_tool
 from .tools.analytics.hourly_sales import hourly_sales_tool
+from .tools.analytics.peak_hours import peak_hours_tool
+from .tools.analytics.sales_anomalies import sales_anomalies_tool
+from .tools.analytics.product_velocity import product_velocity_tool
+from .tools.analytics.low_movement import low_movement_tool
 from .tools.analytics.sales_gaps import sales_gaps_tool
 from .tools.analytics.year_over_year import year_over_year_tool
 from .tools.item_lookup import item_lookup_tool
@@ -25,6 +29,10 @@ TOOLS: list[Tool] = [
     cross_sell_opportunities_tool,
     daily_report_tool,
     hourly_sales_tool,
+    peak_hours_tool,
+    sales_anomalies_tool,
+    product_velocity_tool,
+    low_movement_tool,
     sales_gaps_tool,
     year_over_year_tool,
     item_lookup_tool,


### PR DESCRIPTION
## Summary
- include four extra analytics tools in `src/tool_list.py`
- document the new tools in the README
- update tests to stub and expect these tools

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_685d7eaa2408832b9fa70e6a7d730044