### PR TITLE
Fix duplicate server.start

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -67,9 +67,6 @@ async def run_server() -> None:
             server.create_initialization_options(),
         )
 
-
-    await server.run()
-
 if __name__ == "__main__":  # pragma: no cover - manual run
     import asyncio
 


### PR DESCRIPTION
## Summary
- avoid calling `server.run()` twice when starting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d87b11188832bad8ff9536faf6fe0