### PR TITLE
Add item filter to sales summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ POST route.
 ### `sales_summary`
 
 Aggregate KPIs between two dates. Use the `group_by` array to break down the
-results by `date`, `hour`, `site`, `category`, or `department`.
+results by `date`, `hour`, `site`, `category`, or `department`. You can also
+filter by a specific item using `item_id` or `item_name`.
 
 ### `sales_trend`
 

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -59,3 +59,11 @@ def test_daily_report_schema():
     assert "item_id" in props
     assert "item_name" in props
     assert "category" in props
+
+
+def test_sales_summary_schema():
+    from src.tools.sales.sales_summary import sales_summary_tool
+
+    props = sales_summary_tool.inputSchema["properties"]
+    assert "item_id" in props
+    assert "item_name" in props


### PR DESCRIPTION
## Summary
- extend `sales_summary` params with `item_id` and `item_name`
- accept item filters in query logic and metadata
- document item filter support in README
- verify schema with new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8934c8d8832bb45abcdf08925701