### PR TITLE
Fix server tool assignment

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -16,7 +16,6 @@ def create_server() -> Server:
     server = Server("mcp-pdi-sales")
 
     tools: List[Tool] = TOOLS
-    server.tools = tools
 
 
 


### PR DESCRIPTION
## Summary
- remove redundant `server.tools` assignment when creating the server

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d9667cd58832baaa97bdab731728c