### PR TITLE
Add Prophet-based sales forecast tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ number of results.
 Identify items selling below a `threshold` between `start_date` and `end_date`.
 Optionally filter by `site_id`.
 
+### `sales_forecast`
+
+Forecast daily sales for `horizon` days beyond the selected range using a Prophet model. Provide `start_date` and `end_date` for the training data.
+
 ## Installation
 
 1. Clone the repository:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
           "product_velocity",
           "low_movement",
           "sales_gaps",
-          "year_over_year"
+          "year_over_year",
+          "sales_forecast"
         ]
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
     "fastapi>=0.115.13",
     "uvicorn>=0.34.3",
+    "prophet>=1.1.5",
     "httpx>=0.28.1",
     "streamlit>=1.46.0",
     "ollama>=0.5.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ python-dateutil==2.9.0.post0
 fastapi>=0.115.13
 uvicorn>=0.34.3
 
+prophet>=1.1.5
+
 # Testing
 pytest>=8.4.1
 pytest-asyncio>=1.0.0

--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -59,7 +59,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 18
+    assert len(resp.json()) == 19
 
 
 def test_fastapi_call_tool(monkeypatch):

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -27,6 +27,7 @@ def load_server(monkeypatch):
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
+        ("src.tools.analytics.sales_forecast", "sales_forecast_tool"),
         ("src.tools.item_lookup", "item_lookup_tool"),
         ("src.tools.site_lookup", "site_lookup_tool"),
         ("src.tools.get_today_date", "get_today_date_tool"),
@@ -48,7 +49,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 18
+    assert len(server.tools) == 19
     assert all(hasattr(t, "name") for t in server.tools)
 
 

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -15,6 +15,7 @@ from .tools.analytics.product_velocity import product_velocity_tool
 from .tools.analytics.low_movement import low_movement_tool
 from .tools.analytics.sales_gaps import sales_gaps_tool
 from .tools.analytics.year_over_year import year_over_year_tool
+from .tools.analytics.sales_forecast import sales_forecast_tool
 from .tools.item_lookup import item_lookup_tool
 from .tools.site_lookup import site_lookup_tool
 from .tools.get_today_date import get_today_date_tool
@@ -35,6 +36,7 @@ TOOLS: list[Tool] = [
     low_movement_tool,
     sales_gaps_tool,
     year_over_year_tool,
+    sales_forecast_tool,
     item_lookup_tool,
     site_lookup_tool,
     get_today_date_tool,

--- a/src/tools/analytics/__init__.py
+++ b/src/tools/analytics/__init__.py
@@ -8,6 +8,7 @@ from .product_velocity import product_velocity_tool
 from .low_movement import low_movement_tool
 from .sales_gaps import sales_gaps_tool
 from .year_over_year import year_over_year_tool
+from .sales_forecast import sales_forecast_tool
 
 __all__ = [
     "daily_report_tool",
@@ -18,4 +19,5 @@ __all__ = [
     "low_movement_tool",
     "sales_gaps_tool",
     "year_over_year_tool",
+    "sales_forecast_tool",
 ]

--- a/src/tools/analytics/sales_forecast.py
+++ b/src/tools/analytics/sales_forecast.py
@@ -1,0 +1,70 @@
+"""Generate a sales forecast using Prophet."""
+
+from typing import Dict, Any
+
+import pandas as pd
+from prophet import Prophet
+from mcp.types import Tool
+
+from ...db.connection import execute_query
+from ...db.models import SALES_FACT_VIEW
+from ..utils import validate_date_range, create_tool_response
+
+
+async def sales_forecast_impl(
+    start_date: str,
+    end_date: str,
+    horizon: int = 7,
+) -> Dict[str, Any]:
+    """Return a forecast of daily sales totals."""
+
+    start_date, end_date = validate_date_range(start_date, end_date)
+
+    sql = f"""
+    SELECT SaleDate AS ds, SUM(GrossSales) AS y
+    FROM {SALES_FACT_VIEW}
+    WHERE SaleDate BETWEEN :start_date AND :end_date
+    GROUP BY SaleDate
+    ORDER BY SaleDate
+    """
+
+    params = {"start_date": start_date, "end_date": end_date}
+
+    try:
+        rows = execute_query(sql, params)
+        df = pd.DataFrame(rows)
+        if df.empty:
+            return create_tool_response([], sql, params, error="No data found")
+        df["ds"] = pd.to_datetime(df["ds"])
+        model = Prophet()
+        model.fit(df)
+        future = model.make_future_dataframe(periods=horizon)
+        forecast = model.predict(future)[["ds", "yhat", "yhat_lower", "yhat_upper"]]
+        forecast["ds"] = forecast["ds"].dt.strftime("%Y-%m-%d")
+        data = forecast.to_dict(orient="records")
+        meta = {"date_range": f"{start_date} to {end_date}", "horizon": horizon}
+        return create_tool_response(data, sql, params, meta)
+    except Exception as exc:  # noqa: BLE001
+        return create_tool_response([], sql, params, error=str(exc))
+
+
+sales_forecast_tool = Tool(
+    name="sales_forecast",
+    description="Forecast daily sales totals using Prophet.",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "start_date": {"type": "string", "format": "date"},
+            "end_date": {"type": "string", "format": "date"},
+            "horizon": {
+                "type": "integer",
+                "default": 7,
+                "description": "Days to forecast beyond end_date",
+            },
+        },
+        "required": ["start_date", "end_date"],
+        "additionalProperties": False,
+    },
+)
+
+sales_forecast_tool._implementation = sales_forecast_impl


### PR DESCRIPTION
## Summary
- add `prophet` dependency
- implement `sales_forecast_tool` to forecast daily sales
- register the tool in code and package metadata
- document usage in README
- adjust tests for the new tool

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9841eb8c832baaca4244b19d1a2d