### PR TITLE
Load .env automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ settings. The variables `DB_SERVER`, `DB_DATABASE`, `DB_USERNAME`, and
 control connection pooling. See the example file for the full list of
 supported variables.
 
+The application automatically loads variables from this `.env` file
+using **python-dotenv** when the database engine module is imported, so
+no additional configuration is required.
+
 
 ## Running the FastAPI server
 

--- a/src/db/engine.py
+++ b/src/db/engine.py
@@ -4,11 +4,16 @@ import os
 import logging
 from urllib.parse import quote_plus
 
+from dotenv import load_dotenv
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import declarative_base
 
 logger = logging.getLogger(__name__)
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 # Get environment variables
 DB_USERNAME = os.getenv('DB_USERNAME')


### PR DESCRIPTION
## Summary
- automatically call `load_dotenv` when importing `src.db.engine`
- note automatic loading of `.env` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9c5a6194832b9847a64a8cb0715f