### PR TITLE
Add transaction lookup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Optionally filter by `site_id`.
 
 Forecast daily sales for `horizon` days beyond the selected range using a Prophet model. Provide `start_date` and `end_date` for the training data.
 
+### `transaction_lookup`
+
+Return all line items associated with a given `transaction_id`. An optional `site_id` parameter restricts results to a specific location.
+
 ## Installation
 
 1. Clone the repository:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "basket": [
           "basket_analysis",
           "item_correlation",
-          "cross_sell_opportunities"
+          "cross_sell_opportunities",
+          "transaction_lookup"
         ],
         "analytics": [
           "daily_report",

--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -20,6 +20,7 @@ def load_app(monkeypatch):
         ("src.tools.basket.basket_analysis", "basket_analysis_tool"),
         ("src.tools.basket.item_correlation", "item_correlation_tool"),
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
+        ("src.tools.basket.transaction_lookup", "transaction_lookup_tool"),
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
         ("src.tools.analytics.peak_hours", "peak_hours_tool"),
@@ -59,7 +60,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 19
+    assert len(resp.json()) == 20
 
 
 def test_fastapi_call_tool(monkeypatch):
@@ -84,6 +85,15 @@ def test_item_lookup_valid(monkeypatch):
     client = TestClient(app)
     resp = client.post("/item_lookup", json={"item_id": 1})
     assert resp.status_code == 200
+
+
+def test_transaction_lookup_call(monkeypatch):
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post("/transaction_lookup", json={"transaction_id": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"] == "transaction_lookup"
 
 def test_openapi_examples(monkeypatch):
     app = load_app(monkeypatch)

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -18,6 +18,7 @@ def load_server(monkeypatch):
         ("src.tools.basket.basket_analysis", "basket_analysis_tool"),
         ("src.tools.basket.item_correlation", "item_correlation_tool"),
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
+        ("src.tools.basket.transaction_lookup", "transaction_lookup_tool"),
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
         ("src.tools.analytics.peak_hours", "peak_hours_tool"),
@@ -49,7 +50,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 19
+    assert len(server.tools) == 20
     assert all(hasattr(t, "name") for t in server.tools)
 
 

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -7,6 +7,7 @@ from .tools.sales.top_items import top_items_tool
 from .tools.basket.basket_analysis import basket_analysis_tool
 from .tools.basket.item_correlation import item_correlation_tool
 from .tools.basket.cross_sell import cross_sell_opportunities_tool
+from .tools.basket.transaction_lookup import transaction_lookup_tool
 from .tools.analytics.daily_report import daily_report_tool
 from .tools.analytics.hourly_sales import hourly_sales_tool
 from .tools.analytics.peak_hours import peak_hours_tool
@@ -28,6 +29,7 @@ TOOLS: list[Tool] = [
     basket_analysis_tool,
     item_correlation_tool,
     cross_sell_opportunities_tool,
+    transaction_lookup_tool,
     daily_report_tool,
     hourly_sales_tool,
     peak_hours_tool,

--- a/src/tools/basket/transaction_lookup.py
+++ b/src/tools/basket/transaction_lookup.py
@@ -1,0 +1,72 @@
+"""Lookup all line items for a transaction"""
+
+from typing import Any, Dict, Optional
+from mcp.types import Tool
+
+from ...db.connection import execute_query
+from ...db.models import SALES_FACT_VIEW
+from ..utils import create_tool_response
+
+
+async def transaction_lookup_impl(
+    transaction_id: int,
+    site_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return all rows from ``V_LLM_SalesFact`` matching ``transaction_id``."""
+    sql = f"""
+    SELECT
+        TransactionID,
+        LineItemNumber,
+        SaleDate,
+        TimeOfDay,
+        SiteID,
+        SiteName,
+        ItemID,
+        ItemName,
+        Category,
+        Department,
+        QtySold,
+        Price,
+        GrossSales
+    FROM {SALES_FACT_VIEW}
+    WHERE TransactionID = :transaction_id
+    """
+    params: Dict[str, Any] = {"transaction_id": transaction_id}
+    if site_id is not None:
+        sql += " AND SiteID = :site_id"
+        params["site_id"] = site_id
+    sql += " ORDER BY LineItemNumber"
+
+    try:
+        results = execute_query(sql, params)
+        for row in results:
+            if "SaleDate" in row and row["SaleDate"] is not None:
+                row["SaleDate"] = str(row["SaleDate"])
+            if "TimeOfDay" in row and row["TimeOfDay"] is not None:
+                row["TimeOfDay"] = str(row["TimeOfDay"])
+        metadata = {"transaction_id": transaction_id, "site_id": site_id}
+        return create_tool_response(results, sql, params, metadata)
+    except Exception as exc:  # pragma: no cover - depends on DB state
+        return create_tool_response([], sql, params, error=str(exc))
+
+
+transaction_lookup_tool = Tool(
+    name="transaction_lookup",
+    description=(
+        "Retrieve all line items belonging to a transaction ID. "
+        "Optionally filter by site_id to ensure results come from a single location."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "transaction_id": {
+                "type": "integer",
+                "description": "TransactionID to lookup",
+            },
+            "site_id": {"type": "integer", "description": "Optional site filter"},
+        },
+        "required": ["transaction_id"],
+        "additionalProperties": False,
+    },
+)
+transaction_lookup_tool._implementation = transaction_lookup_impl


### PR DESCRIPTION
## Summary
- implement `transaction_lookup` basket tool
- register new tool
- document in README
- test tool registration and endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9c516340832ba1a0f2eba31daad4