### PR TITLE
Register basket metrics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Optionally filter by `site_id`.
 
 Forecast daily sales for `horizon` days beyond the selected range using a Prophet model. Provide `start_date` and `end_date` for the training data.
 
+### `basket_metrics`
+
+Compute overall basket-level metrics like transaction counts, total quantity, total sales, and the average number of items per transaction between `start_date` and `end_date`. Optionally filter by `site_id`.
+
 ## Installation
 
 1. Clone the repository:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "basket": [
           "basket_analysis",
           "item_correlation",
-          "cross_sell_opportunities"
+          "cross_sell_opportunities",
+          "basket_metrics"
         ],
         "analytics": [
           "daily_report",

--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -20,6 +20,7 @@ def load_app(monkeypatch):
         ("src.tools.basket.basket_analysis", "basket_analysis_tool"),
         ("src.tools.basket.item_correlation", "item_correlation_tool"),
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
+        ("src.tools.basket.basket_metrics", "basket_metrics_tool"),
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
         ("src.tools.analytics.peak_hours", "peak_hours_tool"),
@@ -59,7 +60,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 19
+    assert len(resp.json()) == 20
 
 
 def test_fastapi_call_tool(monkeypatch):

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -18,6 +18,7 @@ def load_server(monkeypatch):
         ("src.tools.basket.basket_analysis", "basket_analysis_tool"),
         ("src.tools.basket.item_correlation", "item_correlation_tool"),
         ("src.tools.basket.cross_sell", "cross_sell_opportunities_tool"),
+        ("src.tools.basket.basket_metrics", "basket_metrics_tool"),
         ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.hourly_sales", "hourly_sales_tool"),
         ("src.tools.analytics.peak_hours", "peak_hours_tool"),
@@ -49,7 +50,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 19
+    assert len(server.tools) == 20
     assert all(hasattr(t, "name") for t in server.tools)
 
 
@@ -68,3 +69,9 @@ def test_sales_summary_schema():
     props = sales_summary_tool.inputSchema["properties"]
     assert "item_id" in props
     assert "item_name" in props
+
+
+def test_basket_metrics_registered(monkeypatch):
+    mcp_server = load_server(monkeypatch)
+    server = mcp_server.create_server()
+    assert any(t.name == "basket_metrics" for t in server.tools)

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -7,6 +7,7 @@ from .tools.sales.top_items import top_items_tool
 from .tools.basket.basket_analysis import basket_analysis_tool
 from .tools.basket.item_correlation import item_correlation_tool
 from .tools.basket.cross_sell import cross_sell_opportunities_tool
+from .tools.basket.basket_metrics import basket_metrics_tool
 from .tools.analytics.daily_report import daily_report_tool
 from .tools.analytics.hourly_sales import hourly_sales_tool
 from .tools.analytics.peak_hours import peak_hours_tool
@@ -28,6 +29,7 @@ TOOLS: list[Tool] = [
     basket_analysis_tool,
     item_correlation_tool,
     cross_sell_opportunities_tool,
+    basket_metrics_tool,
     daily_report_tool,
     hourly_sales_tool,
     peak_hours_tool,


### PR DESCRIPTION
## Summary
- register `basket_metrics_tool` in tool list
- document the tool in the README and add it to package.json
- update FastAPI and MCP tests for the new tool
- add dedicated test ensuring `basket_metrics` is registered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9c54c940832b8c40795c468b2d68