### PR TITLE
Update tests for tool count

### DIFF
--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -61,7 +61,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 20
+    assert len(resp.json()) == 21
 
 
 def test_fastapi_call_tool(monkeypatch):

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -51,7 +51,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 20
+    assert len(server.tools) == 21
     assert all(hasattr(t, "name") for t in server.tools)
 
 


### PR DESCRIPTION
## Summary
- update FastAPI server test to expect 21 tools
- update tool registration test for 21 tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da8bdd9cc832babaafb3ef6064d36