### PR TITLE
Fix JSON syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
           "basket_analysis",
           "item_correlation",
           "cross_sell_opportunities",
-          "basket_metrics"
+          "basket_metrics",
           "transaction_lookup"
         ],
         "analytics": [


### PR DESCRIPTION
## Summary
- fix syntax error in package.json by adding missing comma after `basket_metrics`
- verified package.json can be loaded with Python's `json` module

## Testing
- `python - <<'EOF'
import json
json.load(open('package.json'))
print('JSON loaded successfully (after fix)')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685da8bac378832baafb71ab30f203e9