### PR TITLE
Fix test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ The frontend also includes options for viewing charts and exporting data:
 - **CSV Export** – Each table includes a **Download CSV** button
   for saving the query results for further analysis.
 
+## Running tests
+
+Install the dependencies, including the `mcp` and `httpx` packages, and run the
+test suite with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install mcp httpx
+pytest
+```
+
+Running `./setup.sh` will also install all required packages.
+
 
 ## Smoke testing
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,3 +2,4 @@
 # Simple helper to install server dependencies
 set -euo pipefail
 python -m pip install -r requirements.txt
+python -m pip install mcp httpx


### PR DESCRIPTION
## Summary
- document running pytest with mcp and httpx installed
- update setup helper to explicitly install these packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbaebf234832b92bbc2707dbfd979