### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Prevent Python from writing pyc files and buffer stdout/stderr
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install build dependencies and ODBC driver for SQL Server
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    gnupg \
+    unixodbc-dev && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/debian/$(. /etc/os-release && echo $VERSION_ID)/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /app
+
+# Install Python dependencies first
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application
+COPY . .
+
+# Default command starts the FastAPI server
+CMD ["uvicorn", "src.fastapi_server:create_app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,24 @@ The frontend also includes options for viewing charts and exporting data:
 - **CSV Export** – Each table includes a **Download CSV** button
   for saving the query results for further analysis.
 
+## Docker
+
+A `Dockerfile` and `docker-compose.yml` are provided for containerised
+deployment. Build the image with:
+
+```bash
+docker build -t mcp-pdi-server .
+```
+
+Create a `.env` file (see `.env.example`) and run:
+
+```bash
+docker compose up
+```
+
+The API will be available on `http://localhost:8000` and the Streamlit
+interface on `http://localhost:8501`.
+
 ## Running tests
 
 Install the dependencies, including the `mcp` and `httpx` packages, and run the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    env_file: .env
+    ports:
+      - "8000:8000"
+    command: uvicorn src.fastapi_server:create_app --host 0.0.0.0 --port 8000
+  streamlit:
+    build: .
+    env_file: .env
+    environment:
+      MCP_API_URL: http://api:8000
+    ports:
+      - "8501:8501"
+    command: streamlit run streamlit_app.py --server.address 0.0.0.0 --server.port 8501
+    depends_on:
+      - api


### PR DESCRIPTION
## Summary
- add Dockerfile for running the FastAPI server
- provide docker-compose setup with API and Streamlit services
- document how to build and run the containers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867316aad2c832ba54ae92d71939d84