### PR TITLE
Add dockerignore to reduce build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+.git
+__pycache__/
+*.py[cod]
+tests/
+# Additional unnecessary files and directories
+src/tests/
+.env
+.env.*
+*.egg-info/
+dist/
+build/
+node_modules/
+venv/
+env/
+ENV/
+.venv
+output/
+temp/
+*.log
+*.csv
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- avoid shipping Git history, caches, and build output by adding a new `.dockerignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_686734c5ef28832b90fb14e6583be788