### PR TITLE
Remove duplicate tool in fastapi test

### DIFF
--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -28,7 +28,6 @@ def load_app(monkeypatch):
         ("src.tools.analytics.sales_anomalies", "sales_anomalies_tool"),
         ("src.tools.analytics.product_velocity", "product_velocity_tool"),
         ("src.tools.analytics.low_movement", "low_movement_tool"),
-        ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
         ("src.tools.item_lookup", "item_lookup_tool"),


### PR DESCRIPTION
## Summary
- remove second mocked daily_report tool in the FastAPI test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686734c79b94832bac975205c0010350