### PR TITLE
Fix apt-key deprecation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg \
     unixodbc-dev && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/debian/$(. /etc/os-release && echo $VERSION_ID)/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-archive-keyring.gpg && \
+    echo "deb [arch=amd64,armhf,arm64 signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/debian/$(. /etc/os-release && echo $VERSION_ID)/prod $(. /etc/os-release && echo $VERSION_CODENAME) main" > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- fetch Microsoft's GPG key to `/usr/share/keyrings/microsoft-archive-keyring.gpg`
- reference the key via `signed-by` when creating `mssql-release.list`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673b268d38832ba4b315723a9929aa