### PR TITLE
Fix duplicate daily_report tool mock

### DIFF
--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -26,7 +26,6 @@ def load_server(monkeypatch):
         ("src.tools.analytics.sales_anomalies", "sales_anomalies_tool"),
         ("src.tools.analytics.product_velocity", "product_velocity_tool"),
         ("src.tools.analytics.low_movement", "low_movement_tool"),
-        ("src.tools.analytics.daily_report", "daily_report_tool"),
         ("src.tools.analytics.sales_gaps", "sales_gaps_tool"),
         ("src.tools.analytics.year_over_year", "year_over_year_tool"),
         ("src.tools.analytics.sales_forecast", "sales_forecast_tool"),


### PR DESCRIPTION
## Summary
- remove duplicate entry for `daily_report_tool` in tests

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673b277a60832b942f40ce28553b15