### PR TITLE
Improve date validation and centralize error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Set `MCP_API_URL` if the API is not running on the default `http://localhost:800
 Each tool is exposed as its own endpoint (e.g. `POST /sales_summary`). The server
 also mounts a streaming SSE interface at `/mcp` using **fastapi-mcp**.
 All endpoints reject unknown parameters and will return a `422` error if extra
-fields are supplied.
+fields are supplied. Dates must be provided in the `YYYY-MM-DD` format.
 Launch it with:
 
 ```bash

--- a/src/fastapi_server.py
+++ b/src/fastapi_server.py
@@ -83,7 +83,10 @@ def create_app() -> FastAPI:
                         )
 
                     filtered_data = {k: v for k, v in data.items() if k in allowed}
-                    return await t._implementation(**filtered_data)
+                    try:
+                        return await t._implementation(**filtered_data)
+                    except ValueError as exc:
+                        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
                 return endpoint_with_body
             else:
@@ -100,7 +103,10 @@ def create_app() -> FastAPI:
                         )
 
                     # For tools with no parameters, just call the implementation
-                    return await t._implementation()
+                    try:
+                        return await t._implementation()
+                    except ValueError as exc:
+                        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
                 return endpoint_no_body
 

--- a/src/tools/utils.py
+++ b/src/tools/utils.py
@@ -20,8 +20,8 @@ def format_date(date_input: Any) -> str:
                 return dt.strftime("%Y-%m-%d")
             except ValueError:
                 continue
-        # Return as-is if no format matches
-        return date_input
+        # If no format matches raise an error
+        raise ValueError(f"Invalid date format: {date_input}. Expected YYYY-MM-DD")
     elif isinstance(date_input, (date, datetime)):
         return date_input.strftime("%Y-%m-%d")
     else:
@@ -102,8 +102,11 @@ def create_tool_response(
 
 def validate_date_range(start_date: str, end_date: str) -> tuple[str, str]:
     """Validate and format date range"""
-    start = format_date(start_date)
-    end = format_date(end_date)
+    try:
+        start = format_date(start_date)
+        end = format_date(end_date)
+    except ValueError as exc:
+        raise ValueError(f"Invalid date range: {exc}") from exc
 
     # Validate dates
     start_dt = datetime.strptime(start, "%Y-%m-%d")


### PR DESCRIPTION
## Summary
- tighten date parsing in `format_date`
- surface date parsing issues via `validate_date_range`
- convert `ValueError` from tools into FastAPI HTTP 422 errors
- document the `YYYY-MM-DD` date format

## Testing
- `scripts/check_format.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2d29ded0832b8d951d4813e8552e