### PR TITLE
Add ticket sentiment and priority tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "uvicorn>=0.34.3",
     "prophet>=1.1.5",
     "httpx>=0.28.1",
+    "textblob>=0.18.0",
     "streamlit>=1.46.0",
     "ollama>=0.5.1",
     "fastapi-mcp>=0.3.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ mcp>=1.9.4
 # Web server
 httpx>=0.28.1
 
+textblob>=0.18.0
+
 streamlit>=1.46.0
 ollama>=0.5.1
 fastapi-mcp>=0.3.4

--- a/src/tests/test_fastapi_server.py
+++ b/src/tests/test_fastapi_server.py
@@ -33,6 +33,8 @@ def load_app(monkeypatch):
         ("src.tools.item_lookup", "item_lookup_tool"),
         ("src.tools.site_lookup", "site_lookup_tool"),
         ("src.tools.get_today_date", "get_today_date_tool"),
+        ("src.tools.tickets.ticket_sentiment", "ticket_sentiment_tool"),
+        ("src.tools.tickets.ticket_priority", "ticket_priority_tool"),
     ]
 
     def make_impl(name):
@@ -62,7 +64,7 @@ def test_fastapi_list_tools(monkeypatch):
     client = TestClient(app)
     resp = client.get("/tools")
     assert resp.status_code == 200
-    assert len(resp.json()) == 21
+    assert len(resp.json()) == 23
 
 
 def test_fastapi_call_tool(monkeypatch):
@@ -88,6 +90,20 @@ def test_item_lookup_valid(monkeypatch):
     assert resp.status_code == 200
 
 
+def test_ticket_sentiment_call(monkeypatch):
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post("/ticket_sentiment", json={"text": "great work"})
+    assert resp.status_code == 200
+
+
+def test_ticket_priority_call(monkeypatch):
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.post("/ticket_priority", json={"text": "urgent issue"})
+    assert resp.status_code == 200
+
+
 def test_transaction_lookup_call(monkeypatch):
     app = load_app(monkeypatch)
     client = TestClient(app)
@@ -105,3 +121,7 @@ def test_openapi_examples(monkeypatch):
         "content"
     ]["application/json"]["schema"]
     assert "example" in item_lookup_schema
+    sentiment_schema = spec["paths"]["/ticket_sentiment"]["post"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]
+    assert "example" in sentiment_schema

--- a/src/tests/test_tools.py
+++ b/src/tests/test_tools.py
@@ -32,6 +32,8 @@ def load_server(monkeypatch):
         ("src.tools.item_lookup", "item_lookup_tool"),
         ("src.tools.site_lookup", "site_lookup_tool"),
         ("src.tools.get_today_date", "get_today_date_tool"),
+        ("src.tools.tickets.ticket_sentiment", "ticket_sentiment_tool"),
+        ("src.tools.tickets.ticket_priority", "ticket_priority_tool"),
     ]
 
     from mcp.types import Tool
@@ -50,7 +52,7 @@ def test_tool_registration(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert hasattr(server, "run")
-    assert len(server.tools) == 21
+    assert len(server.tools) == 23
     assert all(hasattr(t, "name") for t in server.tools)
 
 
@@ -75,3 +77,15 @@ def test_basket_metrics_registered(monkeypatch):
     mcp_server = load_server(monkeypatch)
     server = mcp_server.create_server()
     assert any(t.name == "basket_metrics" for t in server.tools)
+
+
+def test_ticket_tools_schema():
+    from src.tools.tickets.ticket_sentiment import ticket_sentiment_tool
+    from src.tools.tickets.ticket_priority import ticket_priority_tool
+
+    sentiment_props = ticket_sentiment_tool.inputSchema["properties"]
+    priority_props = ticket_priority_tool.inputSchema["properties"]
+
+    assert set(sentiment_props) == {"text"}
+    assert set(priority_props) == {"text"}
+

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -21,6 +21,8 @@ from .tools.analytics.sales_forecast import sales_forecast_tool
 from .tools.item_lookup import item_lookup_tool
 from .tools.site_lookup import site_lookup_tool
 from .tools.get_today_date import get_today_date_tool
+from .tools.tickets.ticket_sentiment import ticket_sentiment_tool
+from .tools.tickets.ticket_priority import ticket_priority_tool
 
 TOOLS: list[Tool] = [
     query_sales_realtime_tool,
@@ -44,4 +46,6 @@ TOOLS: list[Tool] = [
     item_lookup_tool,
     site_lookup_tool,
     get_today_date_tool,
+    ticket_sentiment_tool,
+    ticket_priority_tool,
 ]

--- a/src/tools/tickets/ticket_priority.py
+++ b/src/tools/tickets/ticket_priority.py
@@ -1,0 +1,33 @@
+"""Simple priority classifier for ticket text."""
+
+from typing import Dict, Any
+
+from mcp.types import Tool
+
+
+async def ticket_priority_impl(text: str) -> Dict[str, Any]:
+    """Return a priority level based on simple keyword matching."""
+    text_lower = text.lower()
+    if any(word in text_lower for word in ["urgent", "immediately", "asap", "critical"]):
+        priority = "high"
+    elif any(word in text_lower for word in ["soon", "whenever", "request"]):
+        priority = "medium"
+    else:
+        priority = "low"
+    return {"priority": priority}
+
+
+ticket_priority_tool = Tool(
+    name="ticket_priority",
+    description="Classify ticket text into a priority level (high, medium, low).",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "Ticket text to classify"},
+        },
+        "required": ["text"],
+        "additionalProperties": False,
+    },
+)
+
+ticket_priority_tool._implementation = ticket_priority_impl

--- a/src/tools/tickets/ticket_sentiment.py
+++ b/src/tools/tickets/ticket_sentiment.py
@@ -1,0 +1,29 @@
+"""Analyze sentiment of a ticket."""
+
+from typing import Dict, Any
+
+from mcp.types import Tool
+from textblob import TextBlob
+
+
+async def ticket_sentiment_impl(text: str) -> Dict[str, Any]:
+    """Return a basic sentiment score for the provided text."""
+    blob = TextBlob(text)
+    score = blob.sentiment.polarity
+    return {"score": score}
+
+
+ticket_sentiment_tool = Tool(
+    name="ticket_sentiment",
+    description="Calculate sentiment polarity for a text string using TextBlob.",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "Ticket text to analyze"},
+        },
+        "required": ["text"],
+        "additionalProperties": False,
+    },
+)
+
+ticket_sentiment_tool._implementation = ticket_sentiment_impl


### PR DESCRIPTION
## Summary
- implement `ticket_sentiment` and `ticket_priority` tools
- register new tools with MCP
- expose them automatically via FastAPI
- test FastAPI examples and schemas for new tools
- bump dependencies for TextBlob

## Testing
- `pip install -q -r requirements.txt`
- `pip install textblob --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687050d96d70832bafc12be26faf59bf